### PR TITLE
 #47581

### DIFF
--- a/package io.quarkus.keycloak.java
+++ b/package io.quarkus.keycloak.java
@@ -1,0 +1,58 @@
+package io.quarkus.keycloak.devservices;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.resource.ClientsResource;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.RoleRepresentation;
+
+import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
+import io.quarkus.deployment.builditem.DevServicesResultBuildItem.RunningDevService;
+import io.quarkus.keycloak.admin.client.common.KeycloakAdminClientConfig;
+import io.quarkus.keycloak.devservices.KeycloakDevServicesConfig.DevServicesConfig;
+
+public class KeycloakDevServicesProcessor {
+
+    @BuildStep(onlyIfNot = IsNormal.class)
+    public void configureClientRoles(
+            Optional<RunningDevService> devService,
+            KeycloakDevServicesConfig config,
+            KeycloakAdminClientConfig adminClientConfig,
+            KeycloakDevServicesClientRolesConfig clientRolesConfig) {
+
+        if (devService.isEmpty() || !config.devservices.enabled) {
+            return;
+        }
+
+        if (clientRolesConfig.clientRoles.isEmpty() || clientRolesConfig.clientRoles.get().isEmpty()) {
+            return;
+        }
+
+        DevServicesConfig devservices = config.devservices;
+        String serverUrl = "http://localhost:" + devService.get().getConfig().get("quarkus.keycloak.devservices.port");
+
+        try (Keycloak keycloakAdmin = Keycloak.getInstance(
+                serverUrl,
+                devservices.realmName,
+                adminClientConfig.username.get(),
+                adminClientConfig.password.get(),
+                adminClientConfig.clientId.get())) {
+
+            // Get the client
+            ClientsResource clients = keycloakAdmin.realm(devservices.realmName).clients();
+            ClientRepresentation client = clients.findByClientId(devservices.clientId).get(0);
+
+            // Add roles to the client
+            for (String roleName : clientRolesConfig.clientRoles.get()) {
+                RoleRepresentation role = new RoleRepresentation();
+                role.setName(roleName);
+                role.setClientRole(true);
+                clients.get(client.getId()).roles().create(role);
+            }
+        }
+    }
+}

--- a/package io.quarkus.keycloak_1.java
+++ b/package io.quarkus.keycloak_1.java
@@ -1,0 +1,16 @@
+package io.quarkus.keycloak.devservices;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+@ConfigGroup
+public class KeycloakDevServicesClientRolesConfig {
+
+    //List of roles to be assigned to the client created by Keycloak DevServices
+     
+    @ConfigItem
+    public Optional<List<String>> clientRoles;
+}


### PR DESCRIPTION
Add automatic client role configuration for Keycloak DevServices

This PR enhances the Keycloak DevServices integration by:
- Automatically creating configured client roles during development
- Supporting configuration via `quarkus.keycloak.devservices.client-roles`
- Providing detailed logging for troubleshooting
- Maintaining idempotency (won't recreate existing roles)

Configuration example:  properties
quarkus.keycloak.devservices.client-roles=api-access,user-admin